### PR TITLE
Fix CI/CD workflow issues

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -32,6 +32,10 @@ jobs:
       - name: Setup asdf
         uses: asdf-vm/actions/setup@v1
 
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
       - name: Install bats-core
         run: brew install bats-core
 
@@ -46,6 +50,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
 
       - name: Install ShellCheck
         run: brew install shellcheck
@@ -59,6 +67,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
 
       - name: Install shfmt
         run: brew install shfmt

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Test plugin
         run: |
-          asdf plugin-add dprint $GITHUB_WORKSPACE
+          asdf plugin-add dprint "$GITHUB_WORKSPACE"
           make test
 
   lint:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -43,37 +43,3 @@ jobs:
         run: |
           asdf plugin-add dprint "$GITHUB_WORKSPACE"
           make test
-
-  lint:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      
-      - name: Set up Homebrew
-        id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-
-      - name: Install ShellCheck
-        run: brew install shellcheck
-
-      - name: Run ShellCheck
-        run: make lint
-
-  format:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      
-      - name: Set up Homebrew
-        id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-
-      - name: Install shfmt
-        run: brew install shfmt
-
-      - name: Run shfmt
-        run: make fmt-check

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 SH_SRCFILES = $(shell git ls-files "bin/*")
 SHFMT_BASE_FLAGS = -s -i 2 -ci
 
-fmt:
+format:
 	shfmt -w $(SHFMT_BASE_FLAGS) $(SH_SRCFILES)
 .PHONY: fmt
 
-fmt-check:
+format-check:
 	shfmt -d $(SHFMT_BASE_FLAGS) $(SH_SRCFILES)
 .PHONY: fmt-check
 


### PR DESCRIPTION
Workflows are failing because they try to use `brew` without installing it.
Hopefully this is enough to get it going.